### PR TITLE
Prevent Jobs from Erroneously Restarting

### DIFF
--- a/lib/agency.js
+++ b/lib/agency.js
@@ -52,10 +52,10 @@ Agency.DEFAULTS = {
   debug: false,
   timeout: 0.25, // 15m
   logger: console,
-  newStatus: 0,
-  startedStatus: 1,
-  completedStatus: 2,
-  errorStatus: 3
+  newStatus: '0',
+  startedStatus: '1',
+  completedStatus: '2',
+  errorStatus: '3'
 };
 
 /**
@@ -171,7 +171,7 @@ Agency.prototype._getStream = function(done) {
     $or: [
       // new and failed jobs
       {
-        status: { $in: [ Agency.DEFAULTS.startedStatus , Agency.DEFAULTS.errorStatus ] }
+        status: { $in: [ Agency.DEFAULTS.newStatus , Agency.DEFAULTS.errorStatus ] }
       },
       // jobs that started and didn't complete after `x` hours
       {

--- a/lib/agency.js
+++ b/lib/agency.js
@@ -26,7 +26,7 @@ function Agency(source, options) {
   }
 
   events.EventEmitter2.call(this);
-  
+
   options = (typeof options === 'object') ? options : {};
 
   if (!source) {
@@ -50,8 +50,12 @@ Agency.DEFAULTS = {
   jobModel: 'AgencyJob',
   completionModel: 'AgencyCompletion',
   debug: false,
-  timeout: 0.25, // 15m 
-  logger: console
+  timeout: 0.25, // 15m
+  logger: console,
+  newStatus: 0,
+  startedStatus: 1,
+  completedStatus: 2,
+  errorStatus: 3
 };
 
 /**
@@ -63,7 +67,7 @@ Agency.DEFAULTS = {
 */
 Agency.prototype.publish = function(namespace, data, callback) {
   callback = (typeof callback === 'function') ? callback : new Function();
-  
+
   var self = this;
   var Job = this.source.model(this.options.jobModel);
   var Completion = this.source.model(this.options.completionModel);
@@ -77,7 +81,7 @@ Agency.prototype.publish = function(namespace, data, callback) {
     }
 
     self._debug('Job %s published', job._ref);
-    
+
     self.once(job._ref, callback);
   });
 
@@ -102,18 +106,17 @@ Agency.prototype.subscribe = function(namespace, handler) {
   this.on(namespace, function(job) {
     self._debug('Starting job %s', job._ref);
 
-    job.status = 'started';
+    job.status = Agency.DEFAULTS.startedStatus;
 
     job.save(function(err) {
-      
       handler(job.contents, function(err) {
         var Completion = self.source.model(self.options.completionModel);
         var params = Array.prototype.slice.call(arguments);
 
-        job.status = err ? 'failed' : 'completed';
+        job.status = err ? Agency.DEFAULTS.errorStatus : Agency.DEFAULTS.completedStatus;
 
         self._debug('Job %s has %s', job._ref, job.status);
-        
+
         job.save(function(err) {
           Completion.create(job._ref, params, function(err) {
             self.emit.apply(self, [job._ref].concat(params));
@@ -146,7 +149,7 @@ Agency.prototype._init = function() {
 Agency.prototype._debug = function() {
   var log = this.options.logger;
   var debug = log.debug || log.info;
-  
+
   if (this.options.debug) {
     debug.apply(log, Array.prototype.slice.call(arguments));
   }
@@ -158,6 +161,7 @@ Agency.prototype._debug = function() {
 * @param {function} done - callback function
 */
 Agency.prototype._getStream = function(done) {
+  var self = this;
   var jobs = this.source.model(this.options.jobModel);
   var completions = this.source.model(this.options.completionModel);
 
@@ -167,11 +171,11 @@ Agency.prototype._getStream = function(done) {
     $or: [
       // new and failed jobs
       {
-        status: { $in: ['new', 'failed'] }
+        status: { $in: [ Agency.DEFAULTS.startedStatus , Agency.DEFAULTS.errorStatus ] }
       },
       // jobs that started and didn't complete after `x` hours
       {
-        status: 'started',
+        status: Agency.DEFAULTS.startedStatus,
         started: { $lt: Date.now() - (this.options.timeout * 60 * 60 * 1000) }
       }
     ]
@@ -189,9 +193,9 @@ Agency.prototype._getStream = function(done) {
 */
 Agency.prototype._addHandlers = function(done) {
   var self = this;
-  
+
   this._debug('Registering job stream handlers');
-  
+
   this._stream.on('data', function(job) {
     self.emit(job.namespace, job);
   });
@@ -221,18 +225,18 @@ Agency.prototype._addHandlers = function(done) {
 Agency.prototype._checkCollections = function(done) {
   this._debug('Registering job specification as storage model');
   this._debug('Registering completion specification as storage model');
-  
+
   var Schema = this.source.base ? this.source.base.Schema : this.source.Schema;
 
   var jobSchema = jobspec(Schema);
   var completionSchema = completionspec(Schema);
-  
+
   var Job = this.source.model(this.options.jobModel, jobSchema);
   var Completion = this.source.model(
     this.options.completionModel,
     completionSchema
   );
-  
+
   async.parallel([
     function checkJobsCollection(done) {
       Job.count({}, function(err, count) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -30,13 +30,13 @@ module.exports = function(Schema) {
     },
     status: {
       type: String,
-      default: 'new',
-      enum: ['new', 'started', 'completed', 'failed']
+      default: '0',
+      enum: ['0', '1', '2', '3']
     },
     _ref: {
       type: String,
       default: createUID
-    } 
+    }
   }, {
     capped: {
       size: 10 * 1024 * 1024,
@@ -46,12 +46,12 @@ module.exports = function(Schema) {
 
   Job.statics.create = function(namespace, contents, callback) {
     var Job = this;
-    
+
     var job = new Job({
       namespace: namespace,
       contents: contents,
       created: Date.now(),
-      status: 'new',
+      status: 0,
       _ref: createUID()
     });
 
@@ -61,5 +61,5 @@ module.exports = function(Schema) {
   };
 
   return Job;
-  
+
 };


### PR DESCRIPTION
Documents in capped collections "cannot grow", so the update of jobs to reflect their failed or completed status was failing.  This maps job statuses to numeric IDs, which are of constant length.